### PR TITLE
Add GitHub Actions workflow for Firebase deploy

### DIFF
--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -1,0 +1,22 @@
+name: Deploy Firebase Hosting
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: '${{ secrets.GITHUB_TOKEN }}'
+          firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT }}'
+          channelId: live
+          projectId: laboratorio-evcs

--- a/README.md
+++ b/README.md
@@ -81,6 +81,12 @@ npm run build
 firebase deploy --only hosting
 ```
 
+### Deploy Automático (GitHub Actions)
+Este repositório possui o workflow [`firebase-deploy.yml`](.github/workflows/firebase-deploy.yml)
+que realiza o build e publica no Firebase sempre que houver push na branch `main`.
+Para funcionar, adicione a chave de serviço do Firebase como secret
+`FIREBASE_SERVICE_ACCOUNT` no GitHub.
+
 ## 🌐 URLs de Produção
 
 - **Site Principal**: https://laboratorio-evcs.web.app


### PR DESCRIPTION
## Summary
- add Firebase deploy workflow triggered on pushes to `main`
- document automatic deploy via GitHub Actions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684792005d208322801841cd06bcd73b