### PR TITLE
Add GitHub Pages workflow

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy GitHub Pages
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: dist/public
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ que realiza o build e publica no Firebase sempre que houver push na branch `main
 Para funcionar, adicione a chave de serviço do Firebase como secret
 `FIREBASE_SERVICE_ACCOUNT` no GitHub.
 
+### Deploy para GitHub Pages
+Também é possível publicar os arquivos estáticos no GitHub Pages.
+Utilize o workflow [`github-pages.yml`](.github/workflows/github-pages.yml),
+que envia o conteúdo de `dist/public` para a branch `gh-pages`.
+Habilite o GitHub Pages apontando para essa branch nas configurações do repositório.
+
 ## 🌐 URLs de Produção
 
 - **Site Principal**: https://laboratorio-evcs.web.app


### PR DESCRIPTION
## Summary
- add a GitHub Pages deployment workflow
- document how to enable GitHub Pages in README

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6847e19677cc8322a3e1655a6fa5c8af