### PR TITLE
Remove leftover submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.env
+npm-debug.log*
+logs/


### PR DESCRIPTION
## Summary
- remove old `Laboratorio-EvCS` submodule entry that broke checkout
- add `.gitignore`

## Testing
- `npm run check` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6847e6cdf12483228dddd973ddcc0739