### PR TITLE
Add dedicated login page with signup and recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Habilite o GitHub Pages apontando para essa branch nas configurações do reposi
 
 ## 👥 Sistema de Usuários
 
+Para acessar o sistema utilize a tela de login em `/login`, onde é possível realizar o login, criar uma nova conta e recuperar a senha.
+
 ### Níveis de Acesso
 - **Administrador**: Acesso total ao sistema
 - **Gerente**: Gerencia sua organização completa

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "@/contexts/auth-context";
 import { DataSyncProvider } from "@/contexts/data-sync-context";
 import ProtectedRoute from "@/components/auth/protected-route";
+import LoginPage from "@/pages/login";
 import MainLayout from "@/components/layout/main-layout";
 import NotFound from "@/pages/not-found";
 import Dashboard from "@/pages/dashboard";
@@ -21,23 +22,28 @@ import ManualAdmin from "@/pages/help/manual-admin";
 
 function Router() {
   return (
-    <ProtectedRoute>
-      <MainLayout>
-        <Switch>
-          <Route path="/" component={Dashboard} />
-          <Route path="/analytics" component={Analytics} />
-          <Route path="/solos/densidade-in-situ" component={DensidadeInSituPage} />
-          <Route path="/solos/densidade-real" component={DensidadeRealPage} />
-          <Route path="/solos/densidade-max-min" component={DensidadeMaxMinPage} />
-          <Route path="/admin" component={AdminDashboard} />
-          <Route path="/admin/users" component={UserManagement} />
-          <Route path="/admin/organizations" component={OrganizationManagement} />
-          <Route path="/help/manual-usuario" component={ManualUsuario} />
-          <Route path="/help/manual-admin" component={ManualAdmin} />
-          <Route component={NotFound} />
-        </Switch>
-      </MainLayout>
-    </ProtectedRoute>
+    <Switch>
+      <Route path="/login" component={LoginPage} />
+      <Route>
+        <ProtectedRoute>
+          <MainLayout>
+            <Switch>
+              <Route path="/" component={Dashboard} />
+              <Route path="/analytics" component={Analytics} />
+              <Route path="/solos/densidade-in-situ" component={DensidadeInSituPage} />
+              <Route path="/solos/densidade-real" component={DensidadeRealPage} />
+              <Route path="/solos/densidade-max-min" component={DensidadeMaxMinPage} />
+              <Route path="/admin" component={AdminDashboard} />
+              <Route path="/admin/users" component={UserManagement} />
+              <Route path="/admin/organizations" component={OrganizationManagement} />
+              <Route path="/help/manual-usuario" component={ManualUsuario} />
+              <Route path="/help/manual-admin" component={ManualAdmin} />
+              <Route component={NotFound} />
+            </Switch>
+          </MainLayout>
+        </ProtectedRoute>
+      </Route>
+    </Switch>
   );
 }
 

--- a/client/src/pages/login.tsx
+++ b/client/src/pages/login.tsx
@@ -1,0 +1,5 @@
+import AuthContainer from "@/components/auth/auth-container";
+
+export default function LoginPage() {
+  return <AuthContainer />;
+}


### PR DESCRIPTION
## Summary
- create a dedicated login page component
- update router to expose `/login`
- document new login screen in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684861577c7c8322a9ec184d61576789