### PR TITLE
Add GitHub Actions workflow for Firebase deployment

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -1,0 +1,38 @@
+name: Deploy to Firebase Hosting
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build_and_deploy:
+    runs-on: ubuntu-latest
+    steps:
+      # Faz o checkout do código do repositório
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      # Configura o Node.js na versão 18
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      # Instala as dependências
+      - name: Install dependencies
+        run: npm ci
+
+      # Executa o build do projeto
+      - name: Build project
+        run: npm run build
+
+      # Instala o Firebase CLI globalmente
+      - name: Install Firebase CLI
+        run: npm install -g firebase-tools
+
+      # Realiza o deploy para o Firebase Hosting
+      - name: Deploy to Firebase Hosting
+        run: firebase deploy --only hosting --token "$FIREBASE_TOKEN"
+        env:
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
## Summary
- add workflow to deploy Firebase Hosting on pushes to `main`

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684876e3465c8322bcbdf22806dbdbb1